### PR TITLE
(fix): Compensate for floating-point calculation

### DIFF
--- a/Math and Logic Puzzles/6.1 The Heavy Pill.md
+++ b/Math and Logic Puzzles/6.1 The Heavy Pill.md
@@ -31,7 +31,7 @@ def heavyPill():
     expected_weight = sum(range(1, 21))
 
     difference = measured_weight - expected_weight
-    heavy_bottle = int(difference / 0.1)
+    heavy_bottle = round((difference * 10) - 1)
     return heavy_bottle
 
 heavy_bottle = heavyPill()


### PR DESCRIPTION
Most of the time the heavy_bottle = heavy_bottle_index + 1. This is caused by floating-point calculation precision errors. The fix, just correct the situation.